### PR TITLE
Option to close message panel after command is finished

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,11 @@ The `options` field can contain the following properties:
 | file | *[optional]* | File path (relative or absolute) to copy the output of the command to |
 | mode | *[optional]* | Mode for starting the process |
 | context | *[optional]* | String of flags indicating which circumstances the command can be run under |
-
+| closeWhenFinished | *[optional]* | Close message panel after the command has finished. The message panel will be kept open if the command exits with an error code, i.e. something else than `0` |
 The `options.mode` field string can be any of the following:
 
 | Type | Description |
+|------|-------------|
 | `silent` | Same as setting `silent` option to true |
 | `terminal` | Opens the command in a separate window |
 | `window` | Same as `terminal` |

--- a/lib/config.js
+++ b/lib/config.js
@@ -62,6 +62,10 @@
               context: {
                 type: 'string',
                 default: 'p'
+              },
+              closeWhenFinished: {
+                type: 'boolean',
+                default: false
               }
             },
             default : {}

--- a/lib/dqs-shell-commands.js
+++ b/lib/dqs-shell-commands.js
@@ -850,6 +850,10 @@
         sounds.play(options.sound);
       }
 
+      if (options.closeWhenFinished && code === 0 && commands.panel) {
+        commands.panel.close();
+      }
+
     });
   }
 


### PR DESCRIPTION
It will keep the message panel open if the command
exits with any other code than `0` so you don't miss
any errors.

I use a shell command to sync to a server frequently and this helps me with both giving a
visual confirmation that it is done and let's me easily catch errors.

The options name is a bit verbose, so feel free to change it! 
Also I was a bit unsure under wich circumstances a commands execution can result in a code that is either `undefined` or `null` (on Windows?), maybe the panel should close in that case as well? 

Anyways, hope you like it. Thanks!